### PR TITLE
HFP-1988 Change style of button when sample is playing or paused

### DIFF
--- a/scripts/audio.js
+++ b/scripts/audio.js
@@ -50,6 +50,7 @@ H5P.Audio = (function ($) {
     var INNER_CONTAINER = 'h5p-audio-inner';
     var AUDIO_BUTTON = 'h5p-audio-minimal-button';
     var PLAY_BUTTON = 'h5p-audio-minimal-play';
+    var PLAY_BUTTON_PAUSED = 'h5p-audio-minimal-play-paused';
     var PAUSE_BUTTON = 'h5p-audio-minimal-pause';
 
     var self = this;
@@ -85,15 +86,15 @@ H5P.Audio = (function ($) {
 
     //Event listeners that change the look of the player depending on events.
     self.audio.addEventListener('ended', function () {
-      audioButton.removeClass(PAUSE_BUTTON).addClass(PLAY_BUTTON);
+      audioButton.removeClass(PAUSE_BUTTON).removeClass(PLAY_BUTTON_PAUSED).addClass(PLAY_BUTTON);
     });
 
     self.audio.addEventListener('play', function () {
-      audioButton.removeClass(PLAY_BUTTON).addClass(PAUSE_BUTTON);
+      audioButton.removeClass(PLAY_BUTTON).removeClass(PLAY_BUTTON_PAUSED).addClass(PAUSE_BUTTON);
     });
 
     self.audio.addEventListener('pause', function () {
-      audioButton.removeClass(PAUSE_BUTTON).addClass(PLAY_BUTTON);
+      audioButton.removeClass(PAUSE_BUTTON).addClass(PLAY_BUTTON_PAUSED);
     });
 
     this.$audioButton = audioButton;

--- a/styles/audio.css
+++ b/styles/audio.css
@@ -27,7 +27,6 @@
   background: -webkit-linear-gradient(top,  rgba(100,152,254,1) 0%,rgba(4,104,206,1) 100%); /* Chrome10+,Safari5.1+ */
   background: -o-linear-gradient(top,  rgba(100,152,254,1) 0%,rgba(4,104,206,1) 100%); /* Opera 11.10+ */
   background: -ms-linear-gradient(top,  rgba(100,152,254,1) 0%,rgba(4,104,206,1) 100%); /* IE10+ */
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6498fe', endColorstr='#0468ce',GradientType=0 ); /* IE6-9 */
 }
 
 .h5p-audio-inner .h5p-audio-minimal-button:hover {
@@ -38,14 +37,14 @@
   content: "\f028";
 }
 
-.h5p-audio-inner .h5p-audio-minimal-play-paused, .h5p-audio-inner .h5p-audio-minimal-pause {
+.h5p-audio-inner .h5p-audio-minimal-play-paused,
+.h5p-audio-inner .h5p-audio-minimal-pause {
   background: rgb(38,170,68); /* Old browsers */
   background: -moz-linear-gradient(top,  rgba(38,170,68,1) 0%, rgba(0,112,10,1) 100%); /* FF3.6+ */
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(38,170,68,1)), color-stop(100%,rgba(0,112,10,1))); /* Chrome,Safari4+ */
   background: -webkit-linear-gradient(top,  rgba(38,170,68,1) 0%,rgba(0,112,10,1) 100%); /* Chrome10+,Safari5.1+ */
   background: -o-linear-gradient(top,  rgba(38,170,68,1) 0%,rgba(0,112,10,1) 100%); /* Opera 11.10+ */
   background: -ms-linear-gradient(top,  rgba(38,170,68,1) 0%,rgba(0,112,10,1) 100%); /* IE10+ */
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6498fe', endColorstr='#0468ce',GradientType=0 ); /* IE6-9 */
 }
 .h5p-audio-inner .h5p-audio-minimal-play-paused:before {
   content: "\f04b";

--- a/styles/audio.css
+++ b/styles/audio.css
@@ -38,6 +38,19 @@
   content: "\f028";
 }
 
+.h5p-audio-inner .h5p-audio-minimal-play-paused, .h5p-audio-inner .h5p-audio-minimal-pause {
+  background: rgb(38,170,68); /* Old browsers */
+  background: -moz-linear-gradient(top,  rgba(38,170,68,1) 0%, rgba(0,112,10,1) 100%); /* FF3.6+ */
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(38,170,68,1)), color-stop(100%,rgba(0,112,10,1))); /* Chrome,Safari4+ */
+  background: -webkit-linear-gradient(top,  rgba(38,170,68,1) 0%,rgba(0,112,10,1) 100%); /* Chrome10+,Safari5.1+ */
+  background: -o-linear-gradient(top,  rgba(38,170,68,1) 0%,rgba(0,112,10,1) 100%); /* Opera 11.10+ */
+  background: -ms-linear-gradient(top,  rgba(38,170,68,1) 0%,rgba(0,112,10,1) 100%); /* IE10+ */
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6498fe', endColorstr='#0468ce',GradientType=0 ); /* IE6-9 */
+}
+.h5p-audio-inner .h5p-audio-minimal-play-paused:before {
+  content: "\f04b";
+}
+
 .h5p-audio-inner .h5p-audio-minimal-pause:before {
   content: "\f04c";
 }


### PR DESCRIPTION
This was a suggestion for Dictation, but it was agreed that this should go into Audio in general.

The background for active samples (either playing or paused) will now be green. The button when paused will now have a different play symbol.

Cmp. [https://h5ptechnology.atlassian.net/browse/HFP-1988](https://h5ptechnology.atlassian.net/browse/HFP-1988)