### PR TITLE
Add Audio Recorder Extension

### DIFF
--- a/library.json
+++ b/library.json
@@ -35,6 +35,11 @@
       "machineName": "FontAwesome",
       "majorVersion": 4,
       "minorVersion": 5
+    },
+    {
+      "machineName": "H5PEditor.AudioRecorder",
+      "majorVersion": 1,
+      "minorVersion": 0
     }
   ]
 }

--- a/semantics.json
+++ b/semantics.json
@@ -4,7 +4,8 @@
     "type": "audio",
     "importance": "high",
     "label": "Source files",
-    "disableCopyright": true
+    "disableCopyright": true,
+    "widgetExtensions": ["AudioRecorder"]
   },
   {
     "name": "playerMode",


### PR DESCRIPTION
When merged in, the audio library will feature the audio recorder extension widget that's already explicitly included for MemoryGame and Dictation.