### PR TITLE
Fix full player height for Chromium based browsers if fitToWrapper is set

### DIFF
--- a/scripts/audio.js
+++ b/scripts/audio.js
@@ -199,7 +199,9 @@ H5P.Audio.prototype.attach = function ($wrapper) {
     audio.style.width = '100%';
     if (!this.isRoot()) {
       // Only set height if this isn't a root
-      audio.style.height = '100%';
+      audio.style.height = (!!window.chrome && this.params.playerMode === 'full') ?
+        '54px' : // Chromium based browsers like Chrome, Edge or Opera need explicit default height
+        '100%';
     }
   }
 


### PR DESCRIPTION
**Problem:** When using the full player mode with the fitToWrapper option, Chromium based browsers like Chrome, Edge or Opera will set a height of 0 unless the audio content's wrapper has an explicit size set. That problem occurs in Column, for example - audio content in full player mode with fitToWrapper set will not show on Chrome.

**Fix:** Apply Chromium's default height for audio elements (54 px) if a Chromium based browser is used in full player mode with the fitToWrapper option set.

_Please note:_ Yes, it's kind of counter-intuitive to set an absolute height when the option is called fitToWrapper, but other browsers like Safari or Firefox have a fixed height anyway and will never scale the audio player to the full _height_ of the wrapper. On the plus side, adding the height to this very audio library instead of setting it in every content type makes developing for H5P easier.