### PR TITLE
HFP-3776 Catch play promise error

### DIFF
--- a/scripts/audio.js
+++ b/scripts/audio.js
@@ -250,7 +250,7 @@ H5P.Audio.prototype.attach = function ($wrapper) {
         // Audio element is visible. Autoplay if autoplay is enabled and it was
         // not explicitly paused by a user
         self.autoPaused = false;
-        self.audio.play();
+        self.play();
       }
     }, {
       root: document.documentElement,
@@ -300,7 +300,8 @@ H5P.Audio.prototype.play = function () {
     this.flowplayer.play();
   }
   if (this.audio !== undefined) {
-    this.audio.play();
+    // play() returns a Promise that can fail, e.g. while autoplaying
+    this.audio.play().catch((error) => {});
   }
 };
 

--- a/scripts/audio.js
+++ b/scripts/audio.js
@@ -301,7 +301,9 @@ H5P.Audio.prototype.play = function () {
   }
   if (this.audio !== undefined) {
     // play() returns a Promise that can fail, e.g. while autoplaying
-    this.audio.play().catch((error) => {});
+    this.audio.play().catch((error) => {
+      console.warn(error);
+    });
   }
 };
 


### PR DESCRIPTION
When merged in, will catch potential `play`-Promise errors that can arise when autoplaying.